### PR TITLE
Add host argument to the connection block to setup an aws ec2 instance

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -66,6 +66,7 @@ resource "aws_instance" "stackstorm" {
     ]
     
     connection {
+      host        = self.public_ip
       type        = "ssh"
       user        = "ubuntu"
       private_key = "${file(var.aws_private_key_pem)}"


### PR DESCRIPTION
This PR uses the public IP of the ec2 instance to connect to it and install st2.

Closes #2 