### PR TITLE
Address terraform deprecation warnings for interpolation-only variables

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,8 +1,8 @@
 # Configure the AWS Provider
 provider "aws" {
-  access_key = "${var.aws_access_key}"
-  secret_key = "${var.aws_secret_key}"
-  region     = "${var.aws_region}"
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  region     = var.aws_region
 }
 
 # Install StackStorm onto an Ubuntu 16.04 (Xenial) image 
@@ -32,14 +32,14 @@ resource "aws_security_group" "stackstorm_allow_ssh_https" {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["${var.public_ip_cidr}"]
+    cidr_blocks = [var.public_ip_cidr]
   }
 
   ingress {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = ["${var.public_ip_cidr}"]
+    cidr_blocks = [var.public_ip_cidr]
   }
 
   egress {
@@ -52,12 +52,12 @@ resource "aws_security_group" "stackstorm_allow_ssh_https" {
 
 # StackStorm EC2 Instance
 resource "aws_instance" "stackstorm" {
-  ami           = "${data.aws_ami.ubuntu1604.id}"
-  instance_type = "${var.aws_instance_type}"
-  key_name      = "${var.aws_key_pair}"
+  ami           = data.aws_ami.ubuntu1604.id
+  instance_type = var.aws_instance_type
+  key_name      = var.aws_key_pair
 
   # allows SSH so we can remote-exec install below
-  security_groups = ["${aws_security_group.stackstorm_allow_ssh_https.name}"]
+  security_groups = [aws_security_group.stackstorm_allow_ssh_https.name]
 
   # install StackStorm
   provisioner "remote-exec" {
@@ -66,9 +66,10 @@ resource "aws_instance" "stackstorm" {
     ]
     
     connection {
+      host        = self.public_ip
       type        = "ssh"
       user        = "ubuntu"
-      private_key = "${file(var.aws_private_key_pem)}"
+      private_key = file(var.aws_private_key_pem)
     }
   }
 }


### PR DESCRIPTION
This PR addresses the terraform 0.12 warnings for deprecated interpolation-only expressions on the aws code. 