### PR TITLE
Typo and firewall fix for digitalocean

### DIFF
--- a/digitalocean/network.tf
+++ b/digitalocean/network.tf
@@ -18,15 +18,18 @@ resource "digitalocean_firewall" "stackstorm_allow_ssh_https" {
   outbound_rule {
     protocol          = "tcp"
     port_range        = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
   }
 
   outbound_rule {
     protocol          = "udp"
     port_range        = "1-65535"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
   }
 
   outbound_rule {
     protocol          = "icmp"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
   }
 }
 

--- a/digitalocean/outputs.tf
+++ b/digitalocean/outputs.tf
@@ -1,6 +1,6 @@
 output "st2_droplet_names" {
   description = "Names of your st2 droplets."
-  value       = digitalocean_droplet.st2[*].ipv4_address
+  value       = digitalocean_droplet.st2[*].name
 }
 
 output "st2_droplet_ips" {


### PR DESCRIPTION
Hi, 

this PR fixes a typo/copy-paste error and an issue with the outbound firewall rules. Now the DigitalOcean setup works as intended. 